### PR TITLE
Clear rtc bit

### DIFF
--- a/src/AB1805_RK.cpp
+++ b/src/AB1805_RK.cpp
@@ -587,6 +587,7 @@ bool AB1805::deepPowerDown(int seconds) {
     }
 
     _log.error("didn't power down");
+    delay(10);
     System.reset();
 
     return true;

--- a/src/AB1805_RK.cpp
+++ b/src/AB1805_RK.cpp
@@ -151,6 +151,8 @@ bool AB1805::resetConfig(uint32_t flags) {
         // and ACAL to 0 (however REG_OSC_CTRL_DEFAULT already sets ACAL to 0)
         oscCtrl |= REG_OSC_CTRL_OSEL | REG_OSC_CTRL_FOS;
     }
+    // oscCtrl |= REG_OSC_CTRL_FOS;
+    writeRegister(REG_CONFIG_KEY, 0xA1, false); // Needed to set config key to update REG_OSC_CTRL
     writeRegister(REG_OSC_CTRL, oscCtrl, false);
     writeRegister(REG_TRICKLE, REG_TRICKLE_DEFAULT, false);
     writeRegister(REG_BREF_CTRL, REG_BREF_CTRL_DEFAULT, false);

--- a/src/AB1805_RK.cpp
+++ b/src/AB1805_RK.cpp
@@ -128,6 +128,7 @@ bool AB1805::resetConfig(uint32_t flags) {
     // Reset configuration registers to default values
     writeRegister(REG_STATUS, REG_STATUS_DEFAULT, false);
     writeRegister(REG_CTRL_1, REG_CTRL_1_DEFAULT, false);
+    clearRegisterBit(REG_CTRL_1, REG_CTRL_1_WRTC, false);
     writeRegister(REG_CTRL_2, REG_CTRL_2_DEFAULT, false);
     writeRegister(REG_INT_MASK, REG_INT_MASK_DEFAULT, false);
     writeRegister(REG_SQW, REG_SQW_DEFAULT, false);

--- a/src/AB1805_RK.h
+++ b/src/AB1805_RK.h
@@ -5,6 +5,8 @@
 
 #include <time.h> // struct tm
 
+#define AB1805_ADDRESS 0x69
+
 /**
  * @brief Class for using the AB1805/AM1805 RTC/watchdog chip
  * 
@@ -37,7 +39,7 @@ public:
      * You typically allocate one of these objects as a global variable as 
      * a singleton. You can only have one of these objects per device.
      */
-    AB1805(TwoWire &wire = Wire, uint8_t i2cAddr = 0x69);
+    AB1805(TwoWire &wire = Wire, uint8_t i2cAddr = AB1805_ADDRESS);
 
     /**
      * @brief Destructor. Not normally used as this object is typically a global object.
@@ -966,7 +968,7 @@ protected:
     /**
      * @brief I2C address, always 0x69 as that is the address hardwired in the AB1805
      */
-    uint8_t i2cAddr = 0x69;
+    uint8_t i2cAddr = AB1805_ADDRESS;
 
     /**
      * @brief Which GPIO is connected to FOUT/nIRQ

--- a/src/AB1805_RK.h
+++ b/src/AB1805_RK.h
@@ -872,9 +872,9 @@ public:
     static const uint8_t   REG_OSC_CTRL_ACIE        = 0x01;      //!< Oscillator control, auto-calibration fail interrupt enable
     static const uint8_t   REG_OSC_CTRL_DEFAULT     = 0x00;      //!< Oscillator control, default value
     static const uint8_t REG_OSC_STATUS             = 0x1d;      //!< Oscillator status register
-    static const uint8_t   REG_OSC_STATUS_XTCAL     = 0x0c;      //!< Oscillator status register, extended crystal calibration
-    static const uint8_t   REG_OSC_STATUS_LKO2      = 0x04;      //!< Oscillator status register, lock OUT2
-    static const uint8_t   REG_OSC_STATUS_OMODE     = 0x01;      //!< Oscillator status register, oscillator mode (read-only)
+    static const uint8_t   REG_OSC_STATUS_XTCAL     = 0xc0;      //!< Oscillator status register, extended crystal calibration
+    static const uint8_t   REG_OSC_STATUS_LKO2      = 0x20;      //!< Oscillator status register, lock OUT2
+    static const uint8_t   REG_OSC_STATUS_OMODE     = 0x10;      //!< Oscillator status register, oscillator mode (read-only)
     static const uint8_t   REG_OSC_STATUS_OF        = 0x02;      //!< Oscillator status register, oscillator failure
     static const uint8_t   REG_OSC_STATUS_ACF       = 0x01;      //!< Oscillator status register, auto-calibration failure
     static const uint8_t REG_CONFIG_KEY             = 0x1f;      //!< Register to set to modify certain other keys


### PR DESCRIPTION
Clears WRTC bit in CTRL1 register in resetConfigs function so that we can check the watchdog rtc clock values

<img width="843" alt="image" src="https://user-images.githubusercontent.com/46975667/217351310-eed0ec2a-0b65-4ec3-9783-40b22ab1f331.png">
